### PR TITLE
Replace the get_item route with get_items

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["Inno", "MSVC", "mysqlshrc", "redist"]
+  "cSpell.words": ["errno", "Inno", "MSVC", "mysqlshrc", "redist"]
 }

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ erDiagram
   cd ..
   cd ..
   ```
+- Then create new clones using [this](#development-process) process.
 
 ### Test Driven Database Development
 

--- a/schema/stored_procedures/p_get_item.sql
+++ b/schema/stored_procedures/p_get_item.sql
@@ -9,20 +9,24 @@ DROP PROCEDURE IF exists p_get_item;
 -- This procedure also supports a request for individual objectives
 -- and goals but as of 2/28/2025 that capability is not used.
 
-DELIMITER //
-CREATE PROCEDURE p_get_item(IN type varchar(30), IN data JSON)
-BEGIN
-	CASE type
-		WHEN "objective" THEN
-		    select * from objective
-            where objective_id = JSON_EXTRACT(data, '$.item_id');
-		WHEN "goal" THEN
-		    select * from goal
-            where goal_id = JSON_EXTRACT(data, '$.item_id');
-		WHEN "task" THEN
-		    select * from task
-            where task_id = JSON_EXTRACT(data, '$.item_id');
-	END CASE;
-END //
+-- This procedure was retired on 5/5/2025 in favor of p_get_items.
 
-DELIMITER ;
+-- DELIMITER //
+-- CREATE PROCEDURE p_get_item(IN type varchar(30), IN data JSON)
+-- BEGIN
+-- 	CASE type
+-- 		WHEN "objective" THEN
+-- 		    select * from objective
+--             where objective_id = JSON_EXTRACT(data, '$.item_id');
+-- 		WHEN "goal" THEN
+-- 		    select * from goal
+--             where goal_id = JSON_EXTRACT(data, '$.item_id');
+-- 		WHEN "task" THEN
+-- 		    -- select * from task
+--             -- where task_id = JSON_EXTRACT(data, '$.item_id');
+--    		    select t.*, t.task_id as item_id, tu.user_login_id from task t inner join task_user tu on t.task_id = tu.task_id
+--             where t.task_id = JSON_EXTRACT(data, '$.item_id');
+-- 	END CASE;
+-- END //
+
+-- DELIMITER ;

--- a/schema/stored_procedures/p_get_items.sql
+++ b/schema/stored_procedures/p_get_items.sql
@@ -13,11 +13,15 @@ BEGIN
 		    create temporary table t1 as select objective_id as item_id, objective.*
             from objective
             where if(JSON_EXTRACT(data, '$.item_id') Is Null, 1 = 1, objective_id = JSON_EXTRACT(data, '$.item_id'));
+--      This branch is not used as of 5/4/2025
+-- 		WHEN "objective" THEN
 		WHEN "goals" THEN
 			create temporary table t1 as select g.goal_id as item_id, g.*
 			from goal g inner join objective_goal og on g.goal_id = og.goal_id
 			where og.objective_id = JSON_EXTRACT(data, '$.parent_id')
             and if(JSON_EXTRACT(data, '$.item_id') Is Null, 1 = 1, g.goal_id = JSON_EXTRACT(data, '$.item_id'));
+--      This branch is not used as of 5/4/2025
+-- 		WHEN "goal" THEN
 		WHEN "tasks" THEN
 			if JSON_UNQUOTE(JSON_EXTRACT(data, '$.view')) = "my-tasks-view" THEN
 				create temporary table t1 as select t.task_id as item_id, t.*, tu.user_login_id
@@ -32,12 +36,24 @@ BEGIN
 				where gt.goal_id = JSON_EXTRACT(data, '$.parent_id')
 				and if(JSON_EXTRACT(data, '$.item_id') Is Null, 1 = 1, t.task_id = JSON_EXTRACT(data, '$.item_id'));
 			END IF;
+		WHEN "task" THEN
+			select t.task_id as item_id, t.*, tu.user_login_id
+			from task t left outer join task_user tu on t.task_id = tu.task_id
+			where t.task_id = JSON_EXTRACT(data, '$.item_id');
 		WHEN "subscriptions" THEN
 			select * from web_push_subscription where unsubscribed_or_expired_dtm Is Null;
+--      This branch is not used as of 5/4/2025
+-- 		WHEN "subscription" THEN
 		WHEN "notes" THEN
 			call p_get_notes(data);
+--      This branch is not used as of 5/4/2025
+-- 		WHEN "note" THEN
 		WHEN "thoughts" THEN
 			call p_get_thoughts(data);
+--      This branch is not used as of 5/4/2025
+-- 		WHEN "thought" THEN
+--      This branch is not used as of 5/4/2025
+-- 		WHEN "user_logins" THEN
 		WHEN "user_login" THEN
 			call p_get_user_login(data);
 	END CASE;

--- a/schema/tables/migration_scripts/p_migrate_goal.sql
+++ b/schema/tables/migration_scripts/p_migrate_goal.sql
@@ -4,13 +4,7 @@ DELIMITER //
 
 create procedure p_migrate_goal()
 	BEGIN
-    insert into goal select goal_id, item_name, item_description, started_dtm
-    , completed_dtm, aborted_dtm, null, created_dtm, 2, last_update_dtm from t_goal
-	where aborted_dtm Is Null;
-
-    insert into goal select goal_id, item_name, item_description, started_dtm
-    , completed_dtm, aborted_dtm, 2, created_dtm, 2, last_update_dtm from t_goal
-	where aborted_dtm Is Not Null;
+    insert into goal select * from t_goal;
     END //
 
 DELIMITER ;

--- a/schema/tables/migration_scripts/p_migrate_objective.sql
+++ b/schema/tables/migration_scripts/p_migrate_objective.sql
@@ -4,13 +4,7 @@ DELIMITER //
 
 create procedure p_migrate_objective()
 	BEGIN
-    insert into objective select objective_id, item_name, item_description, started_dtm
-    , completed_dtm, aborted_dtm, null, created_dtm, 2, last_update_dtm from t_objective
-	where aborted_dtm Is Null;
-
-    insert into objective select objective_id, item_name, item_description, started_dtm
-    , completed_dtm, aborted_dtm, 2, created_dtm, 2, last_update_dtm from t_objective
-	where aborted_dtm Is Not Null;
+    insert into objective select * from t_objective;
     END //
 
 DELIMITER ;

--- a/schema/tables/migration_scripts/p_migrate_task.sql
+++ b/schema/tables/migration_scripts/p_migrate_task.sql
@@ -4,31 +4,7 @@ DELIMITER //
 
 create procedure p_migrate_task()
 	BEGIN
-    insert into task select task_id, item_name, item_description, started_dtm, null, paused_dtm
-    , completed_dtm, null, aborted_dtm, null, created_dtm, 2, last_update_dtm from t_task
-	where started_dtm Is Null
-    and   aborted_dtm Is Null;
-
-    insert into task select task_id, item_name, item_description, started_dtm, 2, paused_dtm
-    , completed_dtm, null, aborted_dtm, null, created_dtm, 2, last_update_dtm from t_task
-	where started_dtm Is Not Null
-    and completed_dtm Is Null
-    and aborted_dtm Is Null;
-
-    insert into task select task_id, item_name, item_description, started_dtm, 2, paused_dtm
-    , completed_dtm, 2, aborted_dtm, null, created_dtm, 2, last_update_dtm from t_task
-	where started_dtm Is Not Null
-    and completed_dtm Is Not Null;
-
-    insert into task select task_id, item_name, item_description, started_dtm, 2, paused_dtm
-    , completed_dtm, null, aborted_dtm, 2, created_dtm, 2, last_update_dtm from t_task
-	where started_dtm Is Not Null
-    and aborted_dtm Is Not Null;
-
-    insert into task select task_id, item_name, item_description, started_dtm, null, paused_dtm
-    , completed_dtm, null, aborted_dtm, 2, created_dtm, 2, last_update_dtm from t_task
-	where started_dtm Is Null
-    and aborted_dtm Is Not Null;
+    insert into task select * from t_task;
     END //
 
 DELIMITER ;

--- a/schema/upgrade_and_test/test_results.txt
+++ b/schema/upgrade_and_test/test_results.txt
@@ -1,14 +1,14 @@
 +-----------------------------------------+---------------------+
 | test_results_line                       | created_dtm         |
 +-----------------------------------------+---------------------+
-| Beginning: task and goal trigger test 1 | 2025-04-13 11:40:42 |
-| SUCCESS: Initial Assertion Correct      | 2025-04-13 11:40:42 |
-| SUCCESS: Final Assertion Correct        | 2025-04-13 11:40:42 |
-| Beginning: task and goal trigger test 2 | 2025-04-13 11:40:42 |
-| SUCCESS: Initial Assertion Correct      | 2025-04-13 11:40:42 |
-| SUCCESS: Final Assertion Correct        | 2025-04-13 11:40:42 |
-| Beginning: calculate worked time test 1 | 2025-04-13 11:40:43 |
-| SUCCESS: Initial Assertion Correct      | 2025-04-13 11:40:43 |
-| SUCCESS: Next Assertion Correct         | 2025-04-13 11:40:45 |
-| SUCCESS: Final Assertion Correct        | 2025-04-13 11:40:45 |
+| Beginning: task and goal trigger test 1 | 2025-05-05 14:01:50 |
+| SUCCESS: Initial Assertion Correct      | 2025-05-05 14:01:50 |
+| SUCCESS: Final Assertion Correct        | 2025-05-05 14:01:50 |
+| Beginning: task and goal trigger test 2 | 2025-05-05 14:01:51 |
+| SUCCESS: Initial Assertion Correct      | 2025-05-05 14:01:51 |
+| SUCCESS: Final Assertion Correct        | 2025-05-05 14:01:51 |
+| Beginning: calculate worked time test 1 | 2025-05-05 14:01:52 |
+| SUCCESS: Initial Assertion Correct      | 2025-05-05 14:01:52 |
+| SUCCESS: Next Assertion Correct         | 2025-05-05 14:01:54 |
+| SUCCESS: Final Assertion Correct        | 2025-05-05 14:01:54 |
 +-----------------------------------------+---------------------+


### PR DESCRIPTION
Retire p_get_item stored procedure. When a stored
procedure is retired, the creation script should
be edited so that only the drop statement is executed.

Return the migration scripts for the objective
, goal, and task to their original state.